### PR TITLE
Prevent possible leak of executable gophermap contents.

### DIFF
--- a/menu.c
+++ b/menu.c
@@ -316,7 +316,7 @@ int gophermap(state *st, char *mapfile, int depth)
 		setenv_cgi(st, mapfile);
 		if ((fp = popen(command, "r")) == NULL) return OK;
 #else
-        return OK;
+		return OK;
 #endif
 	}
 	else

--- a/menu.c
+++ b/menu.c
@@ -311,13 +311,15 @@ int gophermap(state *st, char *mapfile, int depth)
 	}
 
 	/* Try to execute or open the mapfile */
-#ifdef HAVE_POPEN
 	if (exe) {
+#ifdef HAVE_POPEN
 		setenv_cgi(st, mapfile);
 		if ((fp = popen(command, "r")) == NULL) return OK;
+#else
+        return OK;
+#endif
 	}
 	else
-#endif
 		if ((fp = fopen(mapfile, "r")) == NULL) return OK;
 
 	/* Read lines one by one */


### PR DESCRIPTION
Whilst reading the sources of gophernicus, I've found a security problem.

```
	/* Try to execute or open the mapfile */
#ifdef HAVE_POPEN
	if (exe) {
		setenv_cgi(st, mapfile);
		if ((fp = popen(command, "r")) == NULL) return OK;
	}
	else
#endif
		if ((fp = fopen(mapfile, "r")) == NULL) return OK;

	/* Read lines one by one */
	while (fgets(line, sizeof(line) - 1, fp)) {
```

If the system doesn't have `popen(3)`, then the contents of executable maps can be leaked to the client.

For example if I have a gophermap:
```
!test

run my script
=./script.sh
```

And an executable shell script in the same dir:
```
#!/bin/sh

/path/to/some/program --password topsecret
```

And I pretend my system doesn't have `popen(3)`:
```
diff --git a/menu.c b/menu.c
index 11004d3..3d9ef76 100644
--- a/menu.c
+++ b/menu.c
@@ -296,7 +296,7 @@ int gophermap(state *st, char *mapfile, int depth)
        }
 
        /* Try to execute or open the mapfile */
-#ifdef HAVE_POPEN
+#if 0
        if (exe) {
                setenv_cgi(st, mapfile);
                if ((fp = popen(mapfile , "r")) == NULL) return OK;
```

If we hit the gophermap:
```
$ ./in.gophernicus                              
/
itest   TITLE   null.host       1
i               null.host       1
irun my script          null.host       1
i               null.host       1
i/path/to/some/program --password topsecret             null.host       1
i______________________________________________________________________         null.host       1
i                     Gophered by Gophernicus/1.6 on OpenBSD/amd64 6.4          null.host       1
.
```

Oops! I've proposed a fix.

P.S.

I'm working on `pledge(2)` and `unveil(2)` support for gophernicus.

Can you tell me what shared memory is used for in gophernicus? It's not totally clear from the source (and for a relative nooby to gopher).

Cheers