### PR TITLE
Allow for installation for xinetd or inetd when systemd is present.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -47,11 +47,15 @@ make your access lists.
 Running with traditional inetd superserver
 ==========================================
 
-If you want to run Gophernicus under the traditional Unix
-inetd, add the below line to your /etc/inetd.conf and restart
-the inetd process.
+If you want to run Gophernicus under the traditional Unix inetd, the 
+below line should be added to your /etc/inetd.conf and the inetd 
+process restarted.
 
 gopher  stream  tcp  nowait  nobody  /usr/sbin/in.gophernicus  in.gophernicus -h <hostname>
+
+The Makefile will automatically do this for you if you have the 
+update(1) script installed, which is the usual case in most current 
+flavors of Linux and BSD.
 
 
 Compiling on Debian Linux (and Ubuntu)

--- a/Makefile
+++ b/Makefile
@@ -198,11 +198,11 @@ install-inetd: install-files install-docs install-root
 	@if update-inetd --add $(INETLIN); then \
 		echo update-inetd install worked ; \
 	else if grep '^gopher' $(INETD) >/dev/null 2>&1 ; then \
-		echo "::::: gopher entry in $(INETD) already present -- please check! :::::"; \
+		echo "::::: Gopher entry in $(INETD) already present -- please check! :::::"; \
 		else echo "Trying to add gopher entry to $(INETD)" ; \
 			echo "$(INETLIN)" >> $(INETD) ; \
 			if [ -r $(INETPID) ] ; then kill -HUP `cat $(INETPID)` ; \
-				else echo "::::: no PID for inetd found, not restarted -- please check! :::::" ; fi ; \
+				else echo "::::: No PID for inetd found, not restarted -- please check! :::::" ; fi ; \
 		fi ; \
 	fi
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ install-root:
 	@echo
 
 install-inetd: install-files install-docs install-root
-	@if update-inetd --add "$(INETLIN)"; then \
+	@if update-inetd --add $(INETLIN); then \
 		echo update-inetd install worked ; \
 	else if grep '^gopher' $(INETD) >/dev/null 2>&1 ; then \
 		echo "::::: gopher entry in $(INETD) already present -- please check! :::::"; \

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,13 @@ BINARY   = in.$(NAME)
 VERSION  = `./version`
 CODENAME = Dungeon Edition
 AUTHOR   = Kim Holviala and others
-EMAIL    = hb9kns+gophernicus@gmail.com
+EMAIL    = gophernicus@gophernicus.org
 STARTED  = 2009
 
 SOURCES = $(NAME).c file.c menu.c string.c platform.c session.c options.c
 HEADERS = functions.h files.h
 OBJECTS = $(SOURCES:.c=.o)
+README  = README.md
 DOCS    = LICENSE README INSTALL TODO ChangeLog README.Gophermap gophertag
 
 INSTALL = PATH=$$PATH:/usr/sbin ./install-sh -o 0 -g 0
@@ -110,8 +111,11 @@ bin2c: bin2c.c
 	$(HOSTCC) bin2c.c -o $@
 	@echo
 
-files.h: bin2c
-	sed -n -e "1,/^ $$/p" README > README.options
+README: $(README)
+	cat $(README) > $@
+
+files.h: bin2c README
+	sed -e '/^(end of option list)/,$$d' README > README.options
 	./bin2c -0 -n README README.options > $@
 	./bin2c -0 LICENSE >> $@
 	./bin2c -n ERROR_GIF error.gif >> $@
@@ -124,7 +128,7 @@ files.h: bin2c
 clean: clean-build clean-deb
 
 clean-build:
-	rm -f $(BINARY) $(OBJECTS) $(HEADERS) README.options bin2c
+	rm -f $(BINARY) $(OBJECTS) $(HEADERS) README.options README bin2c
 
 clean-deb:
 	if [ -d debian/$(PACKAGE) ]; then fakeroot debian/rules clean; fi
@@ -313,8 +317,8 @@ loc:
 #
 # Fix copyright notes
 #
-copyright:
-	sed -i .stupid -e "s/Copyright .c. 2.*$$/Copyright (c) $(STARTED)-`date +%Y` $(AUTHOR) <$(EMAIL)>/" *.c *.h LICENSE README debian/copyright
+copyright: README
+	sed -i .stupid -e "s/Copyright .c. 2.*$$/Copyright (c) $(STARTED)-`date +%Y` $(AUTHOR) <$(EMAIL)>/" *.c *.h LICENSE $(README) debian/copyright
 	sed -i .stupid -e "s/Maintainer: .*$$/Maintainer: $(AUTHOR) <$(EMAIL)>/" debian/control
 	rm -f *.stupid debian/*.stupid
 

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ NAME     = gophernicus
 PACKAGE  = $(NAME)
 BINARY   = in.$(NAME)
 VERSION  = `./version`
-CODENAME = Prison Edition
-AUTHOR   = Kim Holviala
-EMAIL    = kimholviala@fastmail.com
+CODENAME = Dungeon Edition
+AUTHOR   = Kim Holviala and others
+EMAIL    = hb9kns+gophernicus@gmail.com
 STARTED  = 2009
 
 SOURCES = $(NAME).c file.c menu.c string.c platform.c session.c options.c

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ MAP     = gophermap
 INETD   = /etc/inetd.conf
 XINETD  = /etc/xinetd.d
 INETLIN = "gopher	stream	tcp	nowait	nobody	$(SBINDIR)/$(BINARY)	$(BINARY) -h `hostname`"
+INETPID = /var/run/inetd.pid
 LAUNCHD = /Library/LaunchDaemons
 PLIST   = org.$(NAME).server.plist
 NET_SRV = /boot/common/settings/network/services
@@ -158,6 +159,7 @@ install-done:
 	@echo
 	@echo "======================================================================"
 	@echo
+	@echo "If there were no errors shown above,"
 	@echo "Gophernicus has now been succesfully installed. To try it out, launch"
 	@echo "your favorite gopher browser and navigate to your gopher root."
 	@echo
@@ -174,7 +176,7 @@ install-done:
 	@echo "======================================================================"
 	@echo
 
-install-files:
+install-files: $(BINARY)
 	mkdir -p $(SBINDIR)
 	$(INSTALL) -s -m 755 $(BINARY) $(SBINDIR)
 	@echo
@@ -193,14 +195,14 @@ install-root:
 	@echo
 
 install-inetd: install-files install-docs install-root
-	if update-inetd --add "$(INETLIN)"; then \
-		: update-inetd worked ; \
+	@if update-inetd --add "$(INETLIN)"; then \
+		echo update-inetd worked ; \
 	else if grep '^gopher' $(INETD) >/dev/null 2>&1 ; then \
-		echo "gopher entry in $(INETD) already present -- please check!"; \
+		echo "::::: gopher entry in $(INETD) already present -- please check! :::::"; \
 		else echo "trying to add gopher entry to $(INETD)" ; \
-			cat "$(INETLIN)" >> $(INETD) ; \
-			if [ -r $(INETPID) ] ; then kill -HUP $(INETPID) ; \
-				else echo "no PID for inetd found, not restarted -- please check!" ; fi ; \
+			echo "$(INETLIN)" >> $(INETD) ; \
+			if [ -r $(INETPID) ] ; then kill -HUP `cat $(INETPID)` ; \
+				else echo "::::: no PID for inetd found, not restarted -- please check! :::::" ; fi ; \
 		fi ; \
 	fi
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ install-inetd: install-files install-docs install-root
 		echo update-inetd install worked ; \
 	else if grep '^gopher' $(INETD) >/dev/null 2>&1 ; then \
 		echo "::::: gopher entry in $(INETD) already present -- please check! :::::"; \
-		else echo "trying to add gopher entry to $(INETD)" ; \
+		else echo "Trying to add gopher entry to $(INETD)" ; \
 			echo "$(INETLIN)" >> $(INETD) ; \
 			if [ -r $(INETPID) ] ; then kill -HUP `cat $(INETPID)` ; \
 				else echo "::::: no PID for inetd found, not restarted -- please check! :::::" ; fi ; \

--- a/README
+++ b/README
@@ -45,6 +45,7 @@ Command line options:
     -nr           Disable root user checking (for debugging)
     -np           Disable HAproxy proxy protocol
     -nx           Disable execution of gophermaps and scripts
+    -nu           Disable personal gopherspaces
 
     -d            Debug output in syslog and /server-status
     -v            Display version number and build date

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Gophernicus - Copyright (c) 2009-2018 Kim Holviala <kimholviala@fastmail.com>
+Gophernicus - Copyright (c) 2009-2019 Kim Holviala and others
 
 Gophernicus is a modern full-featured (and hopefully) secure gopher
 daemon. It is licensed under the BSD license.
@@ -44,6 +44,7 @@ Command line options:
     -nm           Disable shared memory use (for debugging)
     -nr           Disable root user checking (for debugging)
     -np           Disable HAproxy proxy protocol
+    -nx           Disable execution of gophermaps and scripts
 
     -d            Debug output in syslog and /server-status
     -v            Display version number and build date
@@ -288,5 +289,3 @@ service = in.gophernicus-tls
 accept  = :::7070
 connect = 127.0.0.1:70
 protocol = proxy
-
-

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
-Gophernicus - Copyright (c) 2009-2019 Kim Holviala and others
+# Gophernicus
+
+*Copyright (c) 2009-2019 Kim Holviala and others*
 
 Gophernicus is a modern full-featured (and hopefully) secure gopher
 daemon. It is licensed under the BSD license.
 
-Command line options:
+## Command line options
+
     -h hostname   Change server hostname (FQDN)      [$HOSTNAME]
     -p port       Change server port                 [70]
     -T port       Change TLS/SSL port                [0 = disabled]
@@ -51,28 +54,26 @@ Command line options:
     -v            Display version number and build date
     -b            Display the BSD license
     -?            Display this help
- 
 
-Setting up a gopher site
-========================
+(end of option list) -- keep this line for automatic extraction!
+
+## Setting up a gopher site
 
 After succesfully installing Gophernicus (see INSTALL) you need to set
 up the gopher root directory. By default Gophernicus serves documents
 from /var/gopher so start by creating that directory and making sure
 it's world-readable. Then, simply add files and directories under your
 root, fire up a gopher browser (Firefox with the OverbiteFF extension,
-Lynx) and open up this URL:
-
-gopher://<HOSTNAME>/   (where <HOSTNAME> is your server hostname)
+Lynx) and open up `gopher://HOSTNAME/`
+(where `HOSTNAME` is your server hostname).
 
 That's it, your first gopher site is now up and running. If the links
-on the root menu don't work make sure you are using the -h <HOSTNAME>
+on the root menu don't work make sure you are using the `-h HOSTNAME`
 parameter in your configuration (with a valid resolveable hostname
-instead of <HOSTNAME> - see INSTALL).
+instead of `HOSTNAME` - see INSTALL).
 
 
-Security
-========
+## Security
 
 Gophernicus has been written with high security in mind. There should
 be no buffer overflows or memory allocation problems so it should be
@@ -84,9 +85,12 @@ world-readable content. Being readable by the server process is not
 enough, all files and directories MUST be world-readable or they are
 simply hidden from all listings and denied if a client asks for them.
 
+The `-nx` option prevents execution of any script or external file,
+and the `-nu` option suppresses scanning for and serving of `~user`
+directories (which are normally at `~/public_html/` for each user).
 
-Gophermaps
-==========
+
+## Gophermaps
 
 By default all gopher menus are automatically generated from the
 content of the directory being viewed. If you want to have
@@ -95,8 +99,7 @@ replace the generated menu with your own you need to take a look at
 gophermaps. See the file README.gophermap for more information.
 
 
-Gophertags
-==========
+## Gophertags
 
 A gophertag file can be used to virtually rename a directory. Let's
 assume that you have a directory called "foo" somewhere - it will
@@ -107,17 +110,19 @@ useful for creating descriptive names for directories without
 littering the file system with spaces and weird characters.
 
 
-Personal gopherspaces
-=====================
+## Personal gopherspaces
 
 Gophernicus supports users personal gopherspaces. If a user has
 world-readable directory called public_gopher/ under his home, a
-request for gopher://<HOSTNAME>/1/~user/ will serve documents from
+request for `gopher://HOSTNAME/1/~user/` will serve documents from
 that directory.
 
+This is suppressed if the `-nu` option is given.
+In this case, any `~` entry which otherwise initiates listing
+of user directories will be displayed literally.
 
-Virtual hosting
-===============
+
+## Virtual hosting
 
 Gophernicus supports virtual hosting, or serving more than one logical
 domain using the same IP address. Since gopher (RFC1436) doesn't
@@ -126,7 +131,7 @@ hacks.
 
 To enable virtual hosting create one or more directories under your
 gopher root which are named after your domain names. The primary vhost
-directory (set with the -h <HOSTNAME> option) must exist or virtual
+directory (set with the `-h HOSTNAME` option) must exist or virtual
 hosting will be disabled. Then simply add content to the hostname
 directories and you're up and running.
 
@@ -141,29 +146,29 @@ they don't specifically tell the server which host they're trying to
 reach.
 
 
-CGI support
-===========
+## CGI support
 
 Gophernicus supports most parts of the CGI/1.1 standard. Most standard
 CGI variables are set, and some non-standard ones are added.
 
 By default all scripts and binaries under any directory called
-/cgi-bin/ are executed as CGI scripts (this includes cgi-bin
+`/cgi-bin/` are executed as CGI scripts (this includes cgi-bin
 directories under users personal gopherspaces). Also, if a gophermap
 is marked executable it is also processed as an CGI script.
 
 As with regular files, CGI scripts must be world-executable (and
 readable) or they will be ignored. Make sure your CGI script is safe
-with ANY user input as poorly coded CGI scripts are the number #1
-security problem with publicly open *nix servers.
+with ANY user input as poorly coded CGI scripts are the number 1
+security problem with publicly open Unix/Linux/BSD servers.
 
+The `-nx` option prevents execution of any script or external file.
+In this case, they will be simply ignored and no output is given.
 
-Output filtering and PHP support
-================================
+## Output filtering and PHP support
 
 In addition to CGI scripts Gophernicus supports output filtering
 scripts. By default output filtering is turned off, but you can turn
-it on by using the -f <FILTERDIR> option, creating that directory
+it on by using the `-f FILTERDIR` option, creating that directory
 and creating one or more scripts in there named by either the file
 suffix, or by the gopher filetype char.
 
@@ -177,7 +182,7 @@ For PHP support install the CLI version of the PHP interpreter and
 then symlink (or copy) that binary to the directory specified with
 -f option using the destination name "php".
 
-$ ln -s /usr/bin/php5-cli /usr/lib/gophernicus/filters/php
+    $ ln -s /usr/bin/php5-cli /usr/lib/gophernicus/filters/php
 
 After that all files with the php suffix will be "filtered" through
 the PHP command line interpreter. In other words, PHP starts working.
@@ -185,8 +190,7 @@ And don't use the CGI version of PHP as it outputs HTTP headers the
 gopher protocol doesn't have.
 
 
-Charset support and conversions
-===============================
+## Charset support and conversions
 
 Gophernicus supports three charsets: US-ASCII, ISO-8859-1 and UTF-8.
 All textual input is internally upconverted to UTF-8 and then
@@ -200,13 +204,12 @@ files WILL be converted to 7-bit US-ASCII. This means that all 8-bit
 charaters WILL BE LOST. This decision was made because no gopher
 client that I tested was reliably cabable of decoding anything else
 than pure US-ASCII. If you want to disable the conversion use the
-"-no" option, or if you'd like to change the default output charset to
-something else than US-ASCII just use for example the "-o ISO-8859-1"
+`-no` option, or if you'd like to change the default output charset to
+something else than US-ASCII just use for example the `-o ISO-8859-1`
 option.
 
 
-Selector rewriting
-==================
+## Selector rewriting
 
 Selector rewriting lets you rewrite parts of the selector on the fly.
 Well, not parts, but really just the start of it. And the rewrite
@@ -218,12 +221,11 @@ existing deeplinks still work.
 
 Examples:
 
-  -R "/~user=/~luser"
-  -R "/old-dir=/new-dir"
+    -R "/~user=/~luser"
+    -R "/old-dir=/new-dir"
 
 
-Session tracking and statistics
-===============================
+## Session tracking and statistics
 
 To enable virtual hosting with gopher (RFC1436) clients Gophernicus
 tracks users and their session. As a side effect of that session
@@ -234,16 +236,15 @@ human users will never hit the limits, but it's possible (and mostly
 preferrable) that a badly behaving crawling agent will be throttled.
 
 The current sessions and other real-time status data can be viewed
-by opening the URL gopher://<HOSTNAME>/0/server-status . This status
+by opening the URL `gopher://HOSTNAME/0/server-status` . This status
 view has been modeled after the Apache server-status which means
 that it's possible to integrate Gophernicus into existing server
 monitoring systems. To ease up such integrations, Gophernicus
 supports HTTP requests of the server-status page using an URL like
-http://<HOSTNAME>:70/server-status?auto
+`http://HOSTNAME:70/server-status?auto` .
 
 
-TLS/SSL and proxy support
-=========================
+## TLS/SSL and proxy support
 
 As of version 2.3 Gophernicus supports the HAproxy proxy protocol
 version 1. This makes it possible to build a cluster of gopher servers
@@ -256,37 +257,38 @@ address. The below sample stunnel configuration is all you need to
 TLS-enable your gopher server. Well, you'll need a certificate too and for
 that I recommend Let's Encrypt.
 
-In addition to configuring Stunnel for TLS you should add -T <TLS port>
+In addition to configuring Stunnel for TLS you should add `-T TLSPORT`
 to Gophernicus options so that it knows which connetions are coming in
-encrypted and which are not. Using proper -T also makes it possible for
-CGI programs to use the $TLS environment variable to know whether the
+encrypted and which are not. Using proper `-T` also makes it possible for
+CGI programs to use the `$TLS` environment variable to know whether the
 current request was encrypted or not.
 
+Example:
 
-;
-; Gophernicus behind Stunnel4 for gopher over TLS
-;
-
-; User/group for stunnel daemon
-setuid = stunnel4
-setgid = stunnel4
-
-; PID file location
-pid = /var/run/stunnel4/gophernicus.pid
-
-; Log to file, not syslog
-output = /var/log/stunnel4/gophernicus.log
-syslog = no
-
-; Certificate in pem format is needed for TLS
-cert = /etc/ssl/private/gophernicus.pem
-
-; Enable TCP wrappers
-libwrap = yes
-service = in.gophernicus-tls
-
-; Gopher over TLS service
-[gophernicus]
-accept  = :::7070
-connect = 127.0.0.1:70
-protocol = proxy
+    ;
+    ; Gophernicus behind Stunnel4 for gopher over TLS
+    ;
+    
+    ; User/group for stunnel daemon
+    setuid = stunnel4
+    setgid = stunnel4
+    
+    ; PID file location
+    pid = /var/run/stunnel4/gophernicus.pid
+    
+    ; Log to file, not syslog
+    output = /var/log/stunnel4/gophernicus.log
+    syslog = no
+    
+    ; Certificate in pem format is needed for TLS
+    cert = /etc/ssl/private/gophernicus.pem
+    
+    ; Enable TCP wrappers
+    libwrap = yes
+    service = in.gophernicus-tls
+    
+    ; Gopher over TLS service
+    [gophernicus]
+    accept  = :::7070
+    connect = 127.0.0.1:70
+    protocol = proxy

--- a/file.c
+++ b/file.c
@@ -366,11 +366,15 @@ void setenv_cgi(state *st, char *script)
  */
 void run_cgi(state *st, char *script, char *arg)
 {
+	if (st->opt_exec) {
+
 	/* Setup environment & execute the binary */
 	if (st->debug) syslog(LOG_INFO, "executing script \"%s\"", script);
 
 	setenv_cgi(st, script);
 	execl(script, script, arg, NULL);
+	}
+	else if (st->debug) syslog(LOG_INFO, "script \"%s\" was blocked by -nx", script);
 
 	/* Didn't work - die */
 	die(st, ERR_ACCESS, NULL);

--- a/gophernicus.c
+++ b/gophernicus.c
@@ -228,7 +228,8 @@ void selector_to_path(state *st)
 
 #ifdef HAVE_PASSWD
 	/* Virtual userdir (~user -> /home/user/public_gopher)? */
-	if (*(st->user_dir) && sstrncmp(st->req_selector, "/~") == MATCH) {
+	if (st->opt_personal_spaces && *(st->user_dir) &&
+	    sstrncmp(st->req_selector, "/~") == MATCH) {
 
 		/* Parse userdir login name & path */;
 		sstrlcpy(buf, st->req_selector + 2);
@@ -464,6 +465,7 @@ void init_state(state *st)
 	st->opt_root = TRUE;
 	st->opt_proxy = TRUE;
 	st->opt_exec = TRUE;
+	st->opt_personal_spaces = TRUE;
 	st->debug = FALSE;
 
 	/* Load default suffix -> filetype mappings */

--- a/gophernicus.c
+++ b/gophernicus.c
@@ -463,6 +463,7 @@ void init_state(state *st)
 	st->opt_shm = TRUE;
 	st->opt_root = TRUE;
 	st->opt_proxy = TRUE;
+	st->opt_exec = TRUE;
 	st->debug = FALSE;
 
 	/* Load default suffix -> filetype mappings */

--- a/gophernicus.h
+++ b/gophernicus.h
@@ -360,6 +360,7 @@ typedef struct {
 	char opt_root;
 	char opt_proxy;
 	char opt_exec;
+	char opt_personal_spaces;
 	char debug;
 } state;
 

--- a/gophernicus.h
+++ b/gophernicus.h
@@ -359,6 +359,7 @@ typedef struct {
 	char opt_shm;
 	char opt_root;
 	char opt_proxy;
+	char opt_exec;
 	char debug;
 } state;
 

--- a/menu.c
+++ b/menu.c
@@ -343,7 +343,7 @@ int gophermap(state *st, char *mapfile, int depth)
 		if (type == '.') return QUIT;
 
 		/* Print a list of users with public_gopher */
-		if (type == '~') {
+		if (type == '~' && st->opt_personal_spaces) {
 #ifdef HAVE_PASSWD
 			userlist(st);
 #endif

--- a/menu.c
+++ b/menu.c
@@ -306,13 +306,18 @@ int gophermap(state *st, char *mapfile, int depth)
 
 	/* Debug output */
 	if (st->debug) {
-		if (exe) syslog(LOG_INFO, "parsing executable gophermap \"%s\"", mapfile);
+		if (exe) {
+			if (st->opt_exec)
+			 syslog(LOG_INFO, "parsing executable gophermap \"%s\"", mapfile);
+			else
+			 syslog(LOG_INFO, "parsing executable gophermap \"%s\" forbidden by -nx", mapfile);
+		}
 		else syslog(LOG_INFO, "parsing static gophermap \"%s\"", mapfile);
 	}
 
 	/* Try to execute or open the mapfile */
 #ifdef HAVE_POPEN
-	if (exe) {
+	if (exe & st->opt_exec) {
 		setenv_cgi(st, mapfile);
 		if ((fp = popen(command, "r")) == NULL) return OK;
 	}
@@ -426,7 +431,7 @@ int gophermap(state *st, char *mapfile, int depth)
 
 	/* Clean up & return */
 #ifdef HAVE_POPEN
-	if (exe) pclose(fp);
+	if (exe & st->opt_exec) pclose(fp);
 	else
 #endif
 		fclose(fp);

--- a/menu.c
+++ b/menu.c
@@ -316,13 +316,15 @@ int gophermap(state *st, char *mapfile, int depth)
 	}
 
 	/* Try to execute or open the mapfile */
-#ifdef HAVE_POPEN
 	if (exe & st->opt_exec) {
+#ifdef HAVE_POPEN
 		setenv_cgi(st, mapfile);
 		if ((fp = popen(command, "r")) == NULL) return OK;
+#else
+		return OK;
+#endif
 	}
 	else
-#endif
 		if ((fp = fopen(mapfile, "r")) == NULL) return OK;
 
 	/* Read lines one by one */

--- a/options.c
+++ b/options.c
@@ -145,6 +145,7 @@ void parse_args(state *st, int argc, char *argv[])
 				if (*optarg == 'r') { st->opt_root = FALSE; break; }
 				if (*optarg == 'p') { st->opt_proxy = FALSE; break; }
 				if (*optarg == 'x') { st->opt_exec = FALSE; break; }
+				if (*optarg == 'u') { st->opt_personal_spaces = FALSE; break; }
 				break;
 
 			case 'd': st->debug = TRUE; break;

--- a/options.c
+++ b/options.c
@@ -144,6 +144,7 @@ void parse_args(state *st, int argc, char *argv[])
 				if (*optarg == 'm') { st->opt_shm = FALSE; break; }
 				if (*optarg == 'r') { st->opt_root = FALSE; break; }
 				if (*optarg == 'p') { st->opt_proxy = FALSE; break; }
+				if (*optarg == 'x') { st->opt_exec = FALSE; break; }
 				break;
 
 			case 'd': st->debug = TRUE; break;

--- a/version
+++ b/version
@@ -4,7 +4,7 @@
 ## Generate Gophernicus version/build number
 ##
 
-DEFAULT="PE"
+DEFAULT="110+"
 
 if which git >/dev/null && test -d .git; then
 	git log | grep -c "^commit"


### PR DESCRIPTION
As-is, ```gophernicus``` will use ```systemd``` if that's present.  Perhaps the installer would rather use ```xinetd``` or ```inetd```, particularly if ```systemd``` support is troublesome (see #4).  This modification allows one to install ```gophernicus``` using those other two super-servers.