### PR TITLE
add -nx flag to block execution of all files and scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ PACKAGE  = $(NAME)
 BINARY   = in.$(NAME)
 VERSION  = `./version`
 CODENAME = Dungeon Edition
-AUTHOR   = Kim Holviala / Yargo Bonetti
-EMAIL    = kimholviala@fastmail.com / hb9kns@gmail.com
+AUTHOR   = Kim Holviala and others
+EMAIL    = hb9kns+gophernicus@gmail.com
 STARTED  = 2009
 
 SOURCES = $(NAME).c file.c menu.c string.c platform.c session.c options.c

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ NAME     = gophernicus
 PACKAGE  = $(NAME)
 BINARY   = in.$(NAME)
 VERSION  = `./version`
-CODENAME = Prison Edition
-AUTHOR   = Kim Holviala
-EMAIL    = kimholviala@fastmail.com
+CODENAME = Dungeon Edition
+AUTHOR   = Kim Holviala / Yargo Bonetti
+EMAIL    = kimholviala@fastmail.com / hb9kns@gmail.com
 STARTED  = 2009
 
 SOURCES = $(NAME).c file.c menu.c string.c platform.c session.c options.c

--- a/README
+++ b/README
@@ -1,5 +1,4 @@
-Gophernicus - Copyright (c) 2009-2018 Kim Holviala <kimholviala@fastmail.com>
- (added -nx option -- 2019 // Yargo Bonetti/HB9KNS)
+Gophernicus - Copyright (c) 2009-2019 Kim Holviala and others
 
 Gophernicus is a modern full-featured (and hopefully) secure gopher
 daemon. It is licensed under the BSD license.

--- a/README
+++ b/README
@@ -1,4 +1,5 @@
 Gophernicus - Copyright (c) 2009-2018 Kim Holviala <kimholviala@fastmail.com>
+ (added -nx option -- 2019 // Yargo Bonetti/HB9KNS)
 
 Gophernicus is a modern full-featured (and hopefully) secure gopher
 daemon. It is licensed under the BSD license.
@@ -44,6 +45,7 @@ Command line options:
     -nm           Disable shared memory use (for debugging)
     -nr           Disable root user checking (for debugging)
     -np           Disable HAproxy proxy protocol
+    -nx           Disable execution of gophermaps and scripts
 
     -d            Debug output in syslog and /server-status
     -v            Display version number and build date
@@ -288,5 +290,3 @@ service = in.gophernicus-tls
 accept  = :::7070
 connect = 127.0.0.1:70
 protocol = proxy
-
-

--- a/file.c
+++ b/file.c
@@ -366,11 +366,15 @@ void setenv_cgi(state *st, char *script)
  */
 void run_cgi(state *st, char *script, char *arg)
 {
+	if (st->opt_exec) {
+
 	/* Setup environment & execute the binary */
 	if (st->debug) syslog(LOG_INFO, "executing script \"%s\"", script);
 
 	setenv_cgi(st, script);
 	execl(script, script, arg, NULL);
+	}
+	else if (st->debug) syslog(LOG_INFO, "script \"%s\" was blocked by -nx", script);
 
 	/* Didn't work - die */
 	die(st, ERR_ACCESS, NULL);

--- a/gophernicus.c
+++ b/gophernicus.c
@@ -463,6 +463,7 @@ void init_state(state *st)
 	st->opt_shm = TRUE;
 	st->opt_root = TRUE;
 	st->opt_proxy = TRUE;
+	st->opt_exec = TRUE;
 	st->debug = FALSE;
 
 	/* Load default suffix -> filetype mappings */

--- a/gophernicus.h
+++ b/gophernicus.h
@@ -359,6 +359,7 @@ typedef struct {
 	char opt_shm;
 	char opt_root;
 	char opt_proxy;
+	char opt_exec;
 	char debug;
 } state;
 

--- a/menu.c
+++ b/menu.c
@@ -306,13 +306,18 @@ int gophermap(state *st, char *mapfile, int depth)
 
 	/* Debug output */
 	if (st->debug) {
-		if (exe) syslog(LOG_INFO, "parsing executable gophermap \"%s\"", mapfile);
+		if (exe) {
+			if (st->opt_exec)
+			 syslog(LOG_INFO, "parsing executable gophermap \"%s\"", mapfile);
+			else
+			 syslog(LOG_INFO, "parsing executable gophermap \"%s\" forbidden by -nx", mapfile);
+		}
 		else syslog(LOG_INFO, "parsing static gophermap \"%s\"", mapfile);
 	}
 
 	/* Try to execute or open the mapfile */
 #ifdef HAVE_POPEN
-	if (exe) {
+	if (exe & st->opt_exec) {
 		setenv_cgi(st, mapfile);
 		if ((fp = popen(command, "r")) == NULL) return OK;
 	}
@@ -426,7 +431,7 @@ int gophermap(state *st, char *mapfile, int depth)
 
 	/* Clean up & return */
 #ifdef HAVE_POPEN
-	if (exe) pclose(fp);
+	if (exe & st->opt_exec) pclose(fp);
 	else
 #endif
 		fclose(fp);

--- a/options.c
+++ b/options.c
@@ -144,6 +144,7 @@ void parse_args(state *st, int argc, char *argv[])
 				if (*optarg == 'm') { st->opt_shm = FALSE; break; }
 				if (*optarg == 'r') { st->opt_root = FALSE; break; }
 				if (*optarg == 'p') { st->opt_proxy = FALSE; break; }
+				if (*optarg == 'x') { st->opt_exec = FALSE; break; }
 				break;
 
 			case 'd': st->debug = TRUE; break;


### PR DESCRIPTION
Using gophernicus on an experimental gopher server with git-only access for users ( gopher://dome.circumlunar.space ), I wanted to have the possibility to suppress processing of executables (gophermaps and scripts), therefore I added an -nx option and corresponding code. Seems to work on my system... Thanks for gophernicus, by the way! ^-^