### PR TITLE
Add -nu flag to disable personal spaces.

### DIFF
--- a/README
+++ b/README
@@ -45,6 +45,7 @@ Command line options:
     -nr           Disable root user checking (for debugging)
     -np           Disable HAproxy proxy protocol
     -nx           Disable execution of gophermaps and scripts
+    -nu           Disable personal gopherspaces
 
     -d            Debug output in syslog and /server-status
     -v            Display version number and build date

--- a/gophernicus.c
+++ b/gophernicus.c
@@ -228,7 +228,8 @@ void selector_to_path(state *st)
 
 #ifdef HAVE_PASSWD
 	/* Virtual userdir (~user -> /home/user/public_gopher)? */
-	if (*(st->user_dir) && sstrncmp(st->req_selector, "/~") == MATCH) {
+	if (st->opt_personal_spaces && *(st->user_dir) &&
+	    sstrncmp(st->req_selector, "/~") == MATCH) {
 
 		/* Parse userdir login name & path */;
 		sstrlcpy(buf, st->req_selector + 2);
@@ -464,6 +465,7 @@ void init_state(state *st)
 	st->opt_root = TRUE;
 	st->opt_proxy = TRUE;
 	st->opt_exec = TRUE;
+	st->opt_personal_spaces = TRUE;
 	st->debug = FALSE;
 
 	/* Load default suffix -> filetype mappings */

--- a/gophernicus.h
+++ b/gophernicus.h
@@ -360,6 +360,7 @@ typedef struct {
 	char opt_root;
 	char opt_proxy;
 	char opt_exec;
+	char opt_personal_spaces;
 	char debug;
 } state;
 

--- a/menu.c
+++ b/menu.c
@@ -341,7 +341,7 @@ int gophermap(state *st, char *mapfile, int depth)
 		if (type == '.') return QUIT;
 
 		/* Print a list of users with public_gopher */
-		if (type == '~') {
+		if (type == '~' && st->opt_personal_spaces) {
 #ifdef HAVE_PASSWD
 			userlist(st);
 #endif

--- a/options.c
+++ b/options.c
@@ -145,6 +145,7 @@ void parse_args(state *st, int argc, char *argv[])
 				if (*optarg == 'r') { st->opt_root = FALSE; break; }
 				if (*optarg == 'p') { st->opt_proxy = FALSE; break; }
 				if (*optarg == 'x') { st->opt_exec = FALSE; break; }
+				if (*optarg == 'u') { st->opt_personal_spaces = FALSE; break; }
 				break;
 
 			case 'd': st->debug = TRUE; break;


### PR DESCRIPTION
Following in the spirit of `-nx`, I use gophernicus on a server with one one user (me) and I'd like it if gophernicus didn't try to look into `/home` at all.

This change adds a `-nu` flag which disables personal spaces.

I wrote this code a while back as part of a pledge/unveil diff for OpenBSD ports. I've peeled the addition of this flag off to make reviewing simpler.

(My end-goal is to unveil `/home` only if `-nx` is not supplied. Similarly, if `-nx` is supplied, gophernicus can be denied of the `getpw` promise, as it no longer needs to look up user `${HOME}`s.)

I need to re-test this, but I'm raising a draft PR to gauge reactions.

Cheers